### PR TITLE
Enabling Appcache for the android webview

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-inappbrowser",
-  "version": "1.7.1",
+  "version": "1.7.1-j5.1",
   "description": "Cordova InAppBrowser Plugin",
   "types": "./types/index.d.ts",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -20,7 +20,7 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
            id="cordova-plugin-inappbrowser"
-      version="1.7.1">
+      version="1.7.1-j5.1">
 
     <name>InAppBrowser</name>
     <description>Cordova InAppBrowser Plugin</description>

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -800,6 +800,9 @@ public class InAppBrowser extends CordovaPlugin {
                     String databasePath = cordova.getActivity().getApplicationContext().getDir("inAppBrowserDB", Context.MODE_PRIVATE).getPath();
                     settings.setDatabasePath(databasePath);
                     settings.setDatabaseEnabled(true);
+                    settings.setAppCacheMaxSize(5 * 1048576);
+                    settings.setAppCachePath(databasePath);
+                    settings.setAppCacheEnabled(true);
                 }
                 settings.setDomStorageEnabled(true);
 

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -800,7 +800,6 @@ public class InAppBrowser extends CordovaPlugin {
                     String databasePath = cordova.getActivity().getApplicationContext().getDir("inAppBrowserDB", Context.MODE_PRIVATE).getPath();
                     settings.setDatabasePath(databasePath);
                     settings.setDatabaseEnabled(true);
-                    settings.setAppCacheMaxSize(5 * 1048576);
                     settings.setAppCachePath(databasePath);
                     settings.setAppCacheEnabled(true);
                 }

--- a/tests/plugin.xml
+++ b/tests/plugin.xml
@@ -20,7 +20,7 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     id="cordova-plugin-inappbrowser-tests"
-    version="1.7.1">
+    version="1.7.1-j5.1">
     <name>Cordova InAppBrowser Plugin Tests</name>
     <license>Apache 2.0</license>
 


### PR DESCRIPTION
Enabling App Caching for the android webview instance. Disabled by default.