### PR TITLE
Creating a new event the inappbrowser can register to

### DIFF
--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -17,7 +17,7 @@
        under the License.
 */
 package org.apache.cordova.inappbrowser;
-
+import android.util.Log;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.Intent;
@@ -84,7 +84,7 @@ public class InAppBrowser extends CordovaPlugin {
     private static final String HIDDEN = "hidden";
     private static final String LOAD_START_EVENT = "loadstart";
     private static final String LOAD_STOP_EVENT = "loadstop";
-    private static final String OPEN_CAMERA_EVENT = "opencamera";
+    private static final String INDUSTRAFORM_EVENT = "industraformevent";
     private static final String LOAD_ERROR_EVENT = "loaderror";
     private static final String CLEAR_ALL_CACHE = "clearcache";
     private static final String CLEAR_SESSION_CACHE = "clearsessioncache";
@@ -408,7 +408,7 @@ public class InAppBrowser extends CordovaPlugin {
             intent.putExtra(Browser.EXTRA_APPLICATION_ID, cordova.getActivity().getPackageName());
             this.cordova.getActivity().startActivity(intent);
             return "";
-        // not catching FileUriExposedException explicitly because buildtools<24 doesn't know about it
+            // not catching FileUriExposedException explicitly because buildtools<24 doesn't know about it
         } catch (java.lang.RuntimeException e) {
             LOG.d(LOG_TAG, "InAppBrowser: Error loading url "+url+":"+ e.toString());
             return e.toString();
@@ -570,7 +570,7 @@ public class InAppBrowser extends CordovaPlugin {
             }
             Boolean wideViewPort = features.get(USER_WIDE_VIEW_PORT);
             if (wideViewPort != null ) {
-		            useWideViewPort = wideViewPort.booleanValue();
+                useWideViewPort = wideViewPort.booleanValue();
             }
         }
 
@@ -585,8 +585,8 @@ public class InAppBrowser extends CordovaPlugin {
              */
             private int dpToPixels(int dipValue) {
                 int value = (int) TypedValue.applyDimension( TypedValue.COMPLEX_UNIT_DIP,
-                                                            (float) dipValue,
-                                                            cordova.getActivity().getResources().getDisplayMetrics()
+                        (float) dipValue,
+                        cordova.getActivity().getResources().getDisplayMetrics()
                 );
 
                 return value;
@@ -694,8 +694,8 @@ public class InAppBrowser extends CordovaPlugin {
                     public boolean onKey(View v, int keyCode, KeyEvent event) {
                         // If the event is a key-down event on the "enter" button
                         if ((event.getAction() == KeyEvent.ACTION_DOWN) && (keyCode == KeyEvent.KEYCODE_ENTER)) {
-                          navigate(edittext.getText().toString());
-                          return true;
+                            navigate(edittext.getText().toString());
+                            return true;
                         }
                         return false;
                     }
@@ -817,11 +817,20 @@ public class InAppBrowser extends CordovaPlugin {
                 inAppWebView.addJavascriptInterface(new Object()
                 {
                     @JavascriptInterface
-                    public void performClick() throws Exception
+                    public void Emit(String event, String json_data) throws Exception
                     {
-                        Log.d("LOGIN::", "Clicked");
+                        try {
+                            JSONObject obj = new JSONObject();
+                            obj.put("type", INDUSTRAFORM_EVENT);
+                            obj.put("event_name", event);
+                            obj.put("event_data", json_data);
+                            sendUpdate(obj, true);
+                        } catch (JSONException ex) {
+                            LOG.d(LOG_TAG, "Should never happen");
+                        }
                     }
-                }, "login");
+                }, "cordovaEvents");
+
                 inAppWebView.setId(Integer.valueOf(6));
                 inAppWebView.getSettings().setLoadWithOverviewMode(true);
                 inAppWebView.getSettings().setUseWideViewPort(useWideViewPort);
@@ -1034,7 +1043,7 @@ public class InAppBrowser extends CordovaPlugin {
             // Update the UI if we haven't already
             if (!newloc.equals(edittext.getText().toString())) {
                 edittext.setText(newloc);
-             }
+            }
 
             try {
                 JSONObject obj = new JSONObject();

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -84,7 +84,7 @@ public class InAppBrowser extends CordovaPlugin {
     private static final String HIDDEN = "hidden";
     private static final String LOAD_START_EVENT = "loadstart";
     private static final String LOAD_STOP_EVENT = "loadstop";
-    private static final String INDUSTRAFORM_EVENT = "industraformevent";
+    private static final String EMITTED_EVENT = "eventemitted";
     private static final String LOAD_ERROR_EVENT = "loaderror";
     private static final String CLEAR_ALL_CACHE = "clearcache";
     private static final String CLEAR_SESSION_CACHE = "clearsessioncache";
@@ -821,7 +821,7 @@ public class InAppBrowser extends CordovaPlugin {
                     {
                         try {
                             JSONObject obj = new JSONObject();
-                            obj.put("type", INDUSTRAFORM_EVENT);
+                            obj.put("type", EMITTED_EVENT);
                             obj.put("event_name", event);
                             obj.put("event_data", json_data);
                             sendUpdate(obj, true);

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -69,6 +69,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.StringTokenizer;
+import android.webkit.JavascriptInterface;
 
 @SuppressLint("SetJavaScriptEnabled")
 public class InAppBrowser extends CordovaPlugin {
@@ -83,6 +84,7 @@ public class InAppBrowser extends CordovaPlugin {
     private static final String HIDDEN = "hidden";
     private static final String LOAD_START_EVENT = "loadstart";
     private static final String LOAD_STOP_EVENT = "loadstop";
+    private static final String OPEN_CAMERA_EVENT = "opencamera";
     private static final String LOAD_ERROR_EVENT = "loaderror";
     private static final String CLEAR_ALL_CACHE = "clearcache";
     private static final String CLEAR_SESSION_CACHE = "clearsessioncache";
@@ -812,6 +814,14 @@ public class InAppBrowser extends CordovaPlugin {
                 }
 
                 inAppWebView.loadUrl(url);
+                inAppWebView.addJavascriptInterface(new Object()
+                {
+                    @JavascriptInterface
+                    public void performClick() throws Exception
+                    {
+                        Log.d("LOGIN::", "Clicked");
+                    }
+                }, "login");
                 inAppWebView.setId(Integer.valueOf(6));
                 inAppWebView.getSettings().setLoadWithOverviewMode(true);
                 inAppWebView.getSettings().setUseWideViewPort(useWideViewPort);

--- a/www/inappbrowser.js
+++ b/www/inappbrowser.js
@@ -36,7 +36,7 @@
             'loadstart': channel.create('loadstart'),
             'loadstop' : channel.create('loadstop'),
             'loaderror' : channel.create('loaderror'),
-            'opencamera' : channel.create('opencamera'),
+            'industraformevent' : channel.create('industraformevent'),
             'exit' : channel.create('exit')
        };
     }

--- a/www/inappbrowser.js
+++ b/www/inappbrowser.js
@@ -36,6 +36,7 @@
             'loadstart': channel.create('loadstart'),
             'loadstop' : channel.create('loadstop'),
             'loaderror' : channel.create('loaderror'),
+            'opencamera' : channel.create('opencamera'),
             'exit' : channel.create('exit')
        };
     }

--- a/www/inappbrowser.js
+++ b/www/inappbrowser.js
@@ -36,7 +36,7 @@
             'loadstart': channel.create('loadstart'),
             'loadstop' : channel.create('loadstop'),
             'loaderror' : channel.create('loaderror'),
-            'industraformevent' : channel.create('industraformevent'),
+            'eventemitted' : channel.create('eventemitted'),
             'exit' : channel.create('exit')
        };
     }


### PR DESCRIPTION
Creating a new event the inappbrowser can register to when declared. This event can be triggered in the browsers page by accessing the cordovaEvents object (in Android). Still to implements for ios and windows