### PR TITLE
Added support on Windows for the eventemitted event.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-inappbrowser",
-  "version": "1.7.1-j5.1",
+  "version": "1.7.1-j5.3",
   "description": "Cordova InAppBrowser Plugin",
   "types": "./types/index.d.ts",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -20,7 +20,7 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
            id="cordova-plugin-inappbrowser"
-      version="1.7.1-j5.1">
+      version="1.7.1-j5.3">
 
     <name>InAppBrowser</name>
     <description>Cordova InAppBrowser Plugin</description>

--- a/src/windows/InAppBrowserProxy.js
+++ b/src/windows/InAppBrowserProxy.js
@@ -75,6 +75,10 @@ function attachNavigationEvents(element, callback) {
                 }
             }
         });
+        element.addEventListener("MSWebViewScriptNotify", function (e) {
+            var event = JSON.parse(e.value);
+            callback({type: "eventemitted", event_name: event.eventName, event_data: e.value}, { keepCallback: true })
+        });
     } else {
         var onError = function () {
             callback({ type: "loaderror", url: this.contentWindow.location}, {keepCallback: true});

--- a/tests/plugin.xml
+++ b/tests/plugin.xml
@@ -20,7 +20,7 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     id="cordova-plugin-inappbrowser-tests"
-    version="1.7.1-j5.1">
+    version="1.7.1-j5.3">
     <name>Cordova InAppBrowser Plugin Tests</name>
     <license>Apache 2.0</license>
 


### PR DESCRIPTION
To get IndustraForms to work on Windows devices, we needed to add support for emitting events, like we can on Android. This pull request adds support for doing this, but only when running SSL.