### PR TITLE
Fix inappbrowser losing event channels

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-inappbrowser",
-  "version": "3.0.0-j5.1",
+  "version": "3.0.0-j5.2",
   "description": "Cordova InAppBrowser Plugin",
   "types": "./types/index.d.ts",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -20,7 +20,7 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
            id="cordova-plugin-inappbrowser"
-      version="3.0.0-j5.1">
+      version="3.0.0-j5.2">
 
     <name>InAppBrowser</name>
     <description>Cordova InAppBrowser Plugin</description>

--- a/tests/plugin.xml
+++ b/tests/plugin.xml
@@ -20,7 +20,7 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     id="cordova-plugin-inappbrowser-tests"
-    version="3.0.0-j5.1">
+    version="3.0.0-j5.2">
     <name>Cordova InAppBrowser Plugin Tests</name>
     <license>Apache 2.0</license>
 

--- a/www/inappbrowser.js
+++ b/www/inappbrowser.js
@@ -30,6 +30,7 @@
     var channel = require('cordova/channel');
     var modulemapper = require('cordova/modulemapper');
     var urlutil = require('cordova/urlutil');
+    var _iab;
 
     function InAppBrowser () {
         this.channels = {
@@ -50,6 +51,7 @@
         },
         close: function (eventname) {
             exec(null, null, 'InAppBrowser', 'close', []);
+            _iab = null;
         },
         show: function (eventname) {
             exec(null, null, 'InAppBrowser', 'show', []);
@@ -97,20 +99,21 @@
         }
 
         strUrl = urlutil.makeAbsolute(strUrl);
-        var iab = new InAppBrowser();
+        if (!_iab)
+            _iab = new InAppBrowser();
 
         callbacks = callbacks || {};
         for (var callbackName in callbacks) {
-            iab.addEventListener(callbackName, callbacks[callbackName]);
+            _iab.addEventListener(callbackName, callbacks[callbackName]);
         }
 
         var cb = function (eventname) {
-            iab._eventHandler(eventname);
+            _iab._eventHandler(eventname);
         };
 
         strWindowFeatures = strWindowFeatures || '';
 
         exec(cb, cb, 'InAppBrowser', 'open', [strUrl, strWindowName, strWindowFeatures]);
-        return iab;
+        return _iab;
     };
 })();


### PR DESCRIPTION
When opening a link with the target `_system`, any existing inappbrowser instance you had open would lose all the event subscriptions that had been setup. I've changed it so that we keep a reference, and only create a new instance of `InAppBrowser` if we don't already have one, which ensures that we don't lose all our event subscriptions.

This has been tested on Android and iOS, and worked without any issues. The only issue I can think of, is if you try and open a URL using `open` and expect to get back a new instance. Not an issue for our use case, but could be a problem for other people.