### PR TITLE
Hide inAppBrowser dialog instead of closing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-inappbrowser",
-  "version": "3.0.0-j5.2",
+  "version": "3.0.0-j5.3",
   "description": "Cordova InAppBrowser Plugin",
   "types": "./types/index.d.ts",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -20,7 +20,7 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
            id="cordova-plugin-inappbrowser"
-      version="3.0.0-j5.2">
+      version="3.0.0-j5.3">
 
     <name>InAppBrowser</name>
     <description>Cordova InAppBrowser Plugin</description>

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -710,7 +710,7 @@ public class InAppBrowser extends CordovaPlugin {
                 dialog.getWindow().getAttributes().windowAnimations = android.R.style.Animation_Dialog;
                 dialog.requestWindowFeature(Window.FEATURE_NO_TITLE);
                 dialog.setCancelable(true);
-                dialog.setInAppBroswer(getInAppBrowser());
+                dialog.setInAppBrowser(getInAppBrowser());
 
                 // Main container layout
                 LinearLayout main = new LinearLayout(cordova.getActivity());

--- a/src/android/InAppBrowserDialog.java
+++ b/src/android/InAppBrowserDialog.java
@@ -49,8 +49,8 @@ public class InAppBrowserDialog extends Dialog {
             // because it does a clean up
             if (this.inAppBrowser.hardwareBack() && this.inAppBrowser.canGoBack()) {
                 this.inAppBrowser.goBack();
-            }  else {
-                this.inAppBrowser.closeDialog();
+            }else{
+                this.hide();
             }
         }
     }

--- a/src/android/InAppBrowserDialog.java
+++ b/src/android/InAppBrowserDialog.java
@@ -37,7 +37,7 @@ public class InAppBrowserDialog extends Dialog {
         this.context = context;
     }
 
-    public void setInAppBroswer(InAppBrowser browser) {
+    public void setInAppBrowser(InAppBrowser browser) {
         this.inAppBrowser = browser;
     }
 

--- a/tests/plugin.xml
+++ b/tests/plugin.xml
@@ -20,7 +20,7 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     id="cordova-plugin-inappbrowser-tests"
-    version="3.0.0-j5.2">
+    version="3.0.0-j5.3">
     <name>Cordova InAppBrowser Plugin Tests</name>
     <license>Apache 2.0</license>
 


### PR DESCRIPTION
In some cases when opening a page in InAppBrowser the canGoBack gets set to false. This means that the code closes the dialog instead of running the goBack(). The InAppBrowser could then get confused and lead to a NullPointerException on the dialog being null. Instead hide the dialog.

This is the best solution in our use case as we do want to just hide the dialog, we never want to close it while we're using the app. The mobile app does close the dialog when the webview reloads, which happens when we logout.

Testing:
* Login
* Open a InAppBrowser page
* go back
* logout
* login
* open a InAppBrowser page
* go back
* open again.... CRASH!!!

Tested on available j5 devices.