### PR TITLE
A fix for the window disappearing immediately on iOS 13

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-inappbrowser",
-  "version": "3.0.0-j5.3",
+  "version": "3.0.0-j5.4",
   "description": "Cordova InAppBrowser Plugin",
   "types": "./types/index.d.ts",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -20,7 +20,7 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
            id="cordova-plugin-inappbrowser"
-      version="3.0.0-j5.3">
+      version="3.0.0-j5.4">
 
     <name>InAppBrowser</name>
     <description>Cordova InAppBrowser Plugin</description>

--- a/src/ios/CDVInAppBrowser.h
+++ b/src/ios/CDVInAppBrowser.h
@@ -30,6 +30,7 @@
 @class CDVInAppBrowserViewController;
 
 @interface CDVInAppBrowser : CDVPlugin {
+    UIWindow * tmpWindow;
 }
 
 @property (nonatomic, retain) CDVInAppBrowserViewController* inAppBrowserViewController;

--- a/tests/plugin.xml
+++ b/tests/plugin.xml
@@ -20,7 +20,7 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     id="cordova-plugin-inappbrowser-tests"
-    version="3.0.0-j5.3">
+    version="3.0.0-j5.4">
     <name>Cordova InAppBrowser Plugin Tests</name>
     <license>Apache 2.0</license>
 


### PR DESCRIPTION
This is a port of [this](https://github.com/apache/cordova-plugin-inappbrowser/pull/534) pull request from the upstream repo. It's slightly modified, because some of the variables it referenced weren't present, and also having the call to `makeKeyAndVisible` conditional on the iOS version didn't work on iOS 13. It wouldn't show the window without it.

I've tested this on all three devices, iPad 2, and both iPad minis, which I believe covers iOS 10, 12, and 13. I'm not sure if we have an iOS 11 device.