### PR TITLE
Port our changes to 3.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-inappbrowser",
-  "version": "3.2.0",
+  "version": "3.2.0-j5.1",
   "description": "Cordova InAppBrowser Plugin",
   "types": "./types/index.d.ts",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -20,7 +20,7 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
            id="cordova-plugin-inappbrowser"
-      version="3.2.0">
+      version="3.2.0-j5.1">
 
     <name>InAppBrowser</name>
     <description>Cordova InAppBrowser Plugin</description>

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -796,7 +796,7 @@ public class InAppBrowser extends CordovaPlugin {
                 dialog.requestWindowFeature(Window.FEATURE_NO_TITLE);
                 dialog.getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN, WindowManager.LayoutParams.FLAG_FULLSCREEN);
                 dialog.setCancelable(true);
-                dialog.setInAppBroswer(getInAppBrowser());
+                dialog.setInAppBrowser(getInAppBrowser());
 
                 // Main container layout
                 LinearLayout main = new LinearLayout(cordova.getActivity());

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -1019,6 +1019,9 @@ public class InAppBrowser extends CordovaPlugin {
                     String databasePath = cordova.getActivity().getApplicationContext().getDir("inAppBrowserDB", Context.MODE_PRIVATE).getPath();
                     settings.setDatabasePath(databasePath);
                     settings.setDatabaseEnabled(true);
+                    settings.setAppCacheMaxSize(5 * 1048576);
+                    settings.setAppCachePath(databasePath);
+                    settings.setAppCacheEnabled(true);
                 }
                 settings.setDomStorageEnabled(true);
 

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -1019,7 +1019,6 @@ public class InAppBrowser extends CordovaPlugin {
                     String databasePath = cordova.getActivity().getApplicationContext().getDir("inAppBrowserDB", Context.MODE_PRIVATE).getPath();
                     settings.setDatabasePath(databasePath);
                     settings.setDatabaseEnabled(true);
-                    settings.setAppCacheMaxSize(5 * 1048576);
                     settings.setAppCachePath(databasePath);
                     settings.setAppCacheEnabled(true);
                 }

--- a/src/android/InAppBrowserDialog.java
+++ b/src/android/InAppBrowserDialog.java
@@ -49,8 +49,8 @@ public class InAppBrowserDialog extends Dialog {
             // because it does a clean up
             if (this.inAppBrowser.hardwareBack() && this.inAppBrowser.canGoBack()) {
                 this.inAppBrowser.goBack();
-            }  else {
-                this.inAppBrowser.closeDialog();
+            }else{
+                this.hide();
             }
         }
     }

--- a/src/android/InAppBrowserDialog.java
+++ b/src/android/InAppBrowserDialog.java
@@ -37,7 +37,7 @@ public class InAppBrowserDialog extends Dialog {
         this.context = context;
     }
 
-    public void setInAppBroswer(InAppBrowser browser) {
+    public void setInAppBrowser(InAppBrowser browser) {
         this.inAppBrowser = browser;
     }
 

--- a/src/windows/InAppBrowserProxy.js
+++ b/src/windows/InAppBrowserProxy.js
@@ -76,13 +76,9 @@ function attachNavigationEvents (element, callback) {
                 }
             }
         });
-        // element.addEventListener("MSWebViewScriptNotify", function (e) {
-        //     callback({type: "message", event_data: e.value}, { keepCallback: true })
-        // });
-        element.webkit={messageHandlers:{cordova_iab: {}}};
-        element.webkit.messageHandlers.cordova_iab.postMessage = function (data){
-            callback({type: "message", data: data}, { keepCallback: true })
-        };
+        element.addEventListener("MSWebViewScriptNotify", function (e) {
+            callback({type: "message", data: e.value}, { keepCallback: true })
+        });
     } else {
         var onError = function () {
             callback({ type: 'loaderror', url: this.contentWindow.location }, {keepCallback: true});

--- a/src/windows/InAppBrowserProxy.js
+++ b/src/windows/InAppBrowserProxy.js
@@ -76,10 +76,13 @@ function attachNavigationEvents (element, callback) {
                 }
             }
         });
-        element.addEventListener("MSWebViewScriptNotify", function (e) {
-            var event = JSON.parse(e.value);
-            callback({type: "eventemitted", event_name: event.eventName, event_data: e.value}, { keepCallback: true })
-        });
+        // element.addEventListener("MSWebViewScriptNotify", function (e) {
+        //     callback({type: "message", event_data: e.value}, { keepCallback: true })
+        // });
+        element.webkit={messageHandlers:{cordova_iab: {}}};
+        element.webkit.messageHandlers.cordova_iab.postMessage = function (data){
+            callback({type: "message", event_data: data}, { keepCallback: true })
+        };
     } else {
         var onError = function () {
             callback({ type: 'loaderror', url: this.contentWindow.location }, {keepCallback: true});

--- a/src/windows/InAppBrowserProxy.js
+++ b/src/windows/InAppBrowserProxy.js
@@ -77,7 +77,7 @@ function attachNavigationEvents (element, callback) {
             }
         });
         element.addEventListener("MSWebViewScriptNotify", function (e) {
-            callback({type: "message", data: e.value}, { keepCallback: true })
+            callback({type: "message", data: JSON.parse(e.value)}, { keepCallback: true })
         });
     } else {
         var onError = function () {

--- a/src/windows/InAppBrowserProxy.js
+++ b/src/windows/InAppBrowserProxy.js
@@ -81,7 +81,7 @@ function attachNavigationEvents (element, callback) {
         // });
         element.webkit={messageHandlers:{cordova_iab: {}}};
         element.webkit.messageHandlers.cordova_iab.postMessage = function (data){
-            callback({type: "message", event_data: data}, { keepCallback: true })
+            callback({type: "message", data: data}, { keepCallback: true })
         };
     } else {
         var onError = function () {

--- a/src/windows/InAppBrowserProxy.js
+++ b/src/windows/InAppBrowserProxy.js
@@ -76,6 +76,10 @@ function attachNavigationEvents (element, callback) {
                 }
             }
         });
+        element.addEventListener("MSWebViewScriptNotify", function (e) {
+            var event = JSON.parse(e.value);
+            callback({type: "eventemitted", event_name: event.eventName, event_data: e.value}, { keepCallback: true })
+        });
     } else {
         var onError = function () {
             callback({ type: 'loaderror', url: this.contentWindow.location }, {keepCallback: true});

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-inappbrowser-tests",
-  "version": "3.2.0",
+  "version": "3.2.0-j5.1",
   "description": "",
   "cordova": {
     "id": "cordova-plugin-inappbrowser-tests",

--- a/tests/plugin.xml
+++ b/tests/plugin.xml
@@ -20,7 +20,7 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     id="cordova-plugin-inappbrowser-tests"
-    version="3.2.0">
+    version="3.2.0-j5.1">
     <name>Cordova InAppBrowser Plugin Tests</name>
     <license>Apache 2.0</license>
 

--- a/www/inappbrowser.js
+++ b/www/inappbrowser.js
@@ -30,6 +30,7 @@
     var channel = require('cordova/channel');
     var modulemapper = require('cordova/modulemapper');
     var urlutil = require('cordova/urlutil');
+    var _iab;
 
     function InAppBrowser () {
         this.channels = {
@@ -59,6 +60,7 @@
         },
         close: function (eventname) {
             exec(null, null, 'InAppBrowser', 'close', []);
+            _iab = null;
         },
         show: function (eventname) {
             exec(null, null, 'InAppBrowser', 'show', []);
@@ -106,20 +108,21 @@
         }
 
         strUrl = urlutil.makeAbsolute(strUrl);
-        var iab = new InAppBrowser();
+        if (!_iab)
+            _iab = new InAppBrowser();
 
         callbacks = callbacks || {};
         for (var callbackName in callbacks) {
-            iab.addEventListener(callbackName, callbacks[callbackName]);
+            _iab.addEventListener(callbackName, callbacks[callbackName]);
         }
 
         var cb = function (eventname) {
-            iab._eventHandler(eventname);
+            _iab._eventHandler(eventname);
         };
 
         strWindowFeatures = strWindowFeatures || '';
 
         exec(cb, cb, 'InAppBrowser', 'open', [strUrl, strWindowName, strWindowFeatures]);
-        return iab;
+        return _iab;
     };
 })();


### PR DESCRIPTION
### Platforms affected

Windows, iOS, and Android

### What does this PR do?

This merges in the following changes from our 3.0.x branch:
https://github.com/j5int/cordova-plugin-inappbrowser/pull/1
https://github.com/j5int/cordova-plugin-inappbrowser/pull/3
https://github.com/j5int/cordova-plugin-inappbrowser/pull/8
https://github.com/j5int/cordova-plugin-inappbrowser/pull/9
https://github.com/j5int/cordova-plugin-inappbrowser/pull/10

These make the following changes:
* Enable the appcache for Android.
* Add support on Windows for something similar to the postMessage API, but not compliant with the same interface.
* Fixes an issue where you could lose all the event channels you were listening to.
* Fixes an issue to do with closing the dialog when going back, which could cause issues.
* Fixes an issue on iOS 13 where the window would close immediately.

### What testing has been done on this change?

I've tested this on iOS 12.3.1, and on Windows 10.

