### PR TITLE
Avoid JS execution getting suspended on hidden IF window

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-inappbrowser",
-  "version": "4.0.0-j5.2",
+  "version": "4.0.0-j5.3",
   "description": "Cordova InAppBrowser Plugin",
   "types": "./types/index.d.ts",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -20,7 +20,7 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
            id="cordova-plugin-inappbrowser"
-      version="4.0.0-j5.2">
+      version="4.0.0-j5.3">
 
     <name>InAppBrowser</name>
     <description>Cordova InAppBrowser Plugin</description>

--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -336,15 +336,7 @@ static CDVWKInAppBrowser* instance = nil;
         return;
     }
     
-    _previousStatusBarStyle = [UIApplication sharedApplication].statusBarStyle;
-    
-    // Run later to avoid the "took a long time" log message.
-    dispatch_async(dispatch_get_main_queue(), ^{
-        if (self.inAppBrowserViewController != nil) {
-            _previousStatusBarStyle = -1;
-            [self.inAppBrowserViewController.presentingViewController dismissViewControllerAnimated:YES completion:nil];
-        }
-    });
+    _previousStatusBarStyle = -1;
 }
 
 - (void)openInCordovaWebView:(NSURL*)url withOptions:(NSString*)options
@@ -1148,6 +1140,11 @@ BOOL isExiting = FALSE;
 }
 
 #pragma mark WKNavigationDelegate
+
+-(void)webViewWebContentProcessDidTerminate:(WKWebView *)webView {
+    NSLog(@"IndustraForm window has been terminated. Reloading the app.");
+    [webView reload];
+}
 
 - (void)webView:(WKWebView *)theWebView didStartProvisionalNavigation:(WKNavigation *)navigation{
     

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-inappbrowser-tests",
-  "version": "4.0.0-j5.2",
+  "version": "4.0.0-j5.3",
   "description": "",
   "cordova": {
     "id": "cordova-plugin-inappbrowser-tests",

--- a/tests/plugin.xml
+++ b/tests/plugin.xml
@@ -20,7 +20,7 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     id="cordova-plugin-inappbrowser-tests"
-    version="4.0.0-j5.2">
+    version="4.0.0-j5.3">
     <name>Cordova InAppBrowser Plugin Tests</name>
     <license>Apache 2.0</license>
 


### PR DESCRIPTION
All JS execution was being paused after calling hide() on a window; but it seems that if you set the window to hidden but don't dismiss it; it stays active but out of view. 

Checked that the IF app stays active by navigating out of the IF window, making a change to form in the desktop, returning to the mobile app over 10 minutes later (enough time for an automatic sync), putting the iPad into flight mode and checking that the form had been synced. 

NOTE: while testing I found that if you have the IF window open in the Safari Web Inspector, the device is in flight mode and you open an IF tile; the IF window content process gets terminated. I initially thought this had been introduced by my change but after being unable to reproduce the behaviour in any other circumstances; and still being able to reproduce the behaviour in that scenario without my changes, I think it's safe to assume that this is an incidental Safari bug.

Either way I've added a method that gets called if the process is terminated which reloads the IF app.