### PR TITLE
Ensure browser exits when closed while hidden

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-inappbrowser",
-  "version": "4.0.0-j5.3",
+  "version": "4.0.0-j5.4",
   "description": "Cordova InAppBrowser Plugin",
   "types": "./types/index.d.ts",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -20,7 +20,7 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
            id="cordova-plugin-inappbrowser"
-      version="4.0.0-j5.3">
+      version="4.0.0-j5.4">
 
     <name>InAppBrowser</name>
     <description>Cordova InAppBrowser Plugin</description>

--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -690,7 +690,6 @@ static CDVWKInAppBrowser* instance = nil;
 @synthesize currentURL;
 
 CGFloat lastReducedStatusBarHeight = 0.0;
-BOOL isExiting = FALSE;
 
 - (id)initWithBrowserOptions: (CDVInAppBrowserOptions*) browserOptions andSettings:(NSDictionary *)settings
 {
@@ -1036,15 +1035,6 @@ BOOL isExiting = FALSE;
     [super viewDidLoad];
 }
 
-- (void)viewDidDisappear:(BOOL)animated
-{
-    [super viewDidDisappear:animated];
-    if (isExiting && (self.navigationDelegate != nil) && [self.navigationDelegate respondsToSelector:@selector(browserExit)]) {
-        [self.navigationDelegate browserExit];
-        isExiting = FALSE;
-    }
-}
-
 - (UIStatusBarStyle)preferredStatusBarStyle
 {
     return UIStatusBarStyleDefault;
@@ -1058,17 +1048,10 @@ BOOL isExiting = FALSE;
 {
     self.currentURL = nil;
     
-    __weak UIViewController* weakSelf = self;
-    
-    // Run later to avoid the "took a long time" log message.
-    dispatch_async(dispatch_get_main_queue(), ^{
-        isExiting = TRUE;
-        if ([weakSelf respondsToSelector:@selector(presentingViewController)]) {
-            [[weakSelf presentingViewController] dismissViewControllerAnimated:YES completion:nil];
-        } else {
-            [[weakSelf parentViewController] dismissViewControllerAnimated:YES completion:nil];
-        }
-    });
+    if ((self.navigationDelegate != nil) && [self.navigationDelegate respondsToSelector:@selector(browserExit)]) {
+        [self.navigationDelegate browserExit];
+    }
+
 }
 
 - (void)navigateTo:(NSURL*)url

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-inappbrowser-tests",
-  "version": "4.0.0-j5.3",
+  "version": "4.0.0-j5.4",
   "description": "",
   "cordova": {
     "id": "cordova-plugin-inappbrowser-tests",

--- a/tests/plugin.xml
+++ b/tests/plugin.xml
@@ -20,7 +20,7 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     id="cordova-plugin-inappbrowser-tests"
-    version="4.0.0-j5.3">
+    version="4.0.0-j5.4">
     <name>Cordova InAppBrowser Plugin Tests</name>
     <license>Apache 2.0</license>
 


### PR DESCRIPTION
* When you call close() on an open window, the close method sets the isExiting flag to true and creates a task that calls dismissViewControllerAnimated
* Once dismissViewControllerAnimated is done with its work and the view has been removed from the view hierarchy,
  viewDidDisappear calls browserExit if the isExiting flag is true (because it would also be called after hide() and you wouldn't want to exit in that case)

The problem is that we were calling close only when the window was hiddden and as a result viewDidDisappear would not be because it has already been removed from the view hierarchy.

If the user signed back in, the isExiting flag would still be true and after the user next navigated away from the IF app the window would finally exit. The user would then try and navigate back into the the IF app without success.

Since viewDidDisappear was only doing something in the isExiting case; I've just removed it and transferred its contents to the close() method so that it will still be called when the window is hidden.

Tested by checking that you could log in, log out, log in and successfully click on an IF tile on both an iPhone 8 emulator and a real iPad Mini 4 