### PR TITLE
Add method for changing window size on Android

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-inappbrowser",
-  "version": "4.0.0-j5.2",
+  "version": "4.0.0-j5.5",
   "description": "Cordova InAppBrowser Plugin",
   "types": "./types/index.d.ts",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -20,7 +20,7 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
            id="cordova-plugin-inappbrowser"
-      version="4.0.0-j5.2">
+      version="4.0.0-j5.5">
 
     <name>InAppBrowser</name>
     <description>Cordova InAppBrowser Plugin</description>

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -338,6 +338,24 @@ public class InAppBrowser extends CordovaPlugin {
             PluginResult pluginResult = new PluginResult(PluginResult.Status.OK);
             pluginResult.setKeepCallback(true);
             this.callbackContext.sendPluginResult(pluginResult);
+        } else if (action.equals("changeWindowSizeIfHidden")) {
+            final int height = args.getInt(0);
+            final int width = args.getInt(1);
+            this.cordova.getActivity().runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    if (dialog != null && !cordova.getActivity().isFinishing() && !dialog.isShowing()) {
+                        WindowManager.LayoutParams lp = new WindowManager.LayoutParams();
+                        lp.copyFrom(dialog.getWindow().getAttributes());
+                        lp.width = width;
+                        lp.height = height;
+                        dialog.getWindow().setAttributes(lp);
+                        callbackContext.success(1);
+                    } else {
+                        callbackContext.success(0);
+                    }
+                }
+            });
         }
         else {
             return false;

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-inappbrowser-tests",
-  "version": "4.0.0-j5.2",
+  "version": "4.0.0-j5.5",
   "description": "",
   "cordova": {
     "id": "cordova-plugin-inappbrowser-tests",

--- a/tests/plugin.xml
+++ b/tests/plugin.xml
@@ -20,7 +20,7 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     id="cordova-plugin-inappbrowser-tests"
-    version="4.0.0-j5.2">
+    version="4.0.0-j5.5">
     <name>Cordova InAppBrowser Plugin Tests</name>
     <license>Apache 2.0</license>
 

--- a/www/inappbrowser.js
+++ b/www/inappbrowser.js
@@ -96,7 +96,11 @@
         },
 
         changeWindowSizeIfHidden: function (height, width, cb) {
-            exec(cb, null, 'InAppBrowser', 'changeWindowSizeIfHidden', [height, width])
+            if (device.platform.toLowerCase() === 'android') {
+                exec(cb, null, 'InAppBrowser', 'changeWindowSizeIfHidden', [height, width])
+            } else {
+                console.warn('changeWindowSizeIfHidden called but not implemented for ' + device.platform)
+            }
         }
     };
 

--- a/www/inappbrowser.js
+++ b/www/inappbrowser.js
@@ -93,6 +93,10 @@
             } else {
                 throw new Error('insertCSS requires exactly one of code or file to be specified');
             }
+        },
+
+        changeWindowSizeIfHidden: function (height, width, cb) {
+            exec(cb, null, 'InAppBrowser', 'changeWindowSizeIfHidden', [height, width])
         }
     };
 


### PR DESCRIPTION
We need to foreground the IAB in order to keep it executing JS on Android; so in order to do this unobtrusively I've added a method for changing the size of the window if it's hidden. It takes three arguments - the new height, width and a callback. The callback returns 1 if the window is hidden and the size was changed; and 0 if the window is not hidden (and the size was not changed). Passing -1 for the height/width to set it to the parent's dimensions.

Testing: 
Added a method on our mobile app that 
* calls this method to make the window 1x1
* shows the window
* hides the window
* calls this method again to set it back to its original dimensions

Verified that:
* The window is not visible when it is shown 
* The window is the correct size when you open an IF tile
* No change is made if the window is not hidden