### PR TITLE
Implement changeWindowSizeIfHidden for iOS and Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-inappbrowser",
-  "version": "4.0.0-j5.5",
+  "version": "4.0.0-j5.6",
   "description": "Cordova InAppBrowser Plugin",
   "types": "./types/index.d.ts",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -20,7 +20,7 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
            id="cordova-plugin-inappbrowser"
-      version="4.0.0-j5.5">
+      version="4.0.0-j5.6">
 
     <name>InAppBrowser</name>
     <description>Cordova InAppBrowser Plugin</description>

--- a/src/ios/CDVWKInAppBrowser.h
+++ b/src/ios/CDVWKInAppBrowser.h
@@ -39,8 +39,8 @@
 @property (nonatomic, copy) NSString* callbackId;
 @property (nonatomic, copy) NSRegularExpression *callbackIdPattern;
 
-@property NSInteger originalHeight;
-@property NSInteger originalWidth;
+@property NSInteger nextHeight;
+@property NSInteger nextWidth;
 
 + (id) getInstance;
 - (void)open:(CDVInvokedUrlCommand*)command;

--- a/src/ios/CDVWKInAppBrowser.h
+++ b/src/ios/CDVWKInAppBrowser.h
@@ -39,6 +39,9 @@
 @property (nonatomic, copy) NSString* callbackId;
 @property (nonatomic, copy) NSRegularExpression *callbackIdPattern;
 
+@property NSInteger originalHeight;
+@property NSInteger originalWidth;
+
 + (id) getInstance;
 - (void)open:(CDVInvokedUrlCommand*)command;
 - (void)close:(CDVInvokedUrlCommand*)command;

--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -90,22 +90,13 @@ static CDVWKInAppBrowser* instance = nil;
 -(void)changeWindowSizeIfHidden:(CDVInvokedUrlCommand*)command
 {
     CDVPluginResult* pluginResult = nil;
-    if (self->tmpWindow) { // tmpWindow gets set to nil when the window is hidden
+    if (_previousStatusBarStyle != -1) { // indicates that the window is not currently hidden (see hide method)
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsInt:0];
     } else {
-        CGRect webViewBounds = [self.webView bounds];
-        NSInteger height = (int)[command.arguments objectAtIndex:0];
-        NSInteger width = (int)[command.arguments objectAtIndex:1];
-
-        if (height == -1) {
-            height = self.originalHeight;
-        }
-        if (width == -1) {
-            width = self.originalWidth;
-        }
-        webViewBounds.size.height = height;
-        webViewBounds.size.width = width;
-        [self.webView setFrame:webViewBounds];
+        NSInteger height = [([command.arguments objectAtIndex:0]) integerValue];
+        NSInteger width = [([command.arguments objectAtIndex:1]) integerValue];
+        self.nextHeight = height;
+        self.nextWidth = width;
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsInt:1];
     }
  
@@ -284,8 +275,8 @@ static CDVWKInAppBrowser* instance = nil;
     if (!browserOptions.hidden) {
         [self show:nil withNoAnimate:browserOptions.hidden];
     }
-    self.originalHeight = [self.webView bounds].size.height;
-    self.originalWidth = [self.webView bounds].size.width;
+    self.nextHeight = -1;
+    self.nextWidth = -1;
 }
 
 - (void)show:(CDVInvokedUrlCommand*)command{
@@ -327,6 +318,10 @@ static CDVWKInAppBrowser* instance = nil;
             __strong __typeof(weakSelf) strongSelf = weakSelf;
             if (!strongSelf->tmpWindow) {
                 CGRect frame = [[UIScreen mainScreen] bounds];
+                if (self.nextHeight != -1)
+                    frame.size.height = self.nextHeight;
+                if (self.nextWidth != -1)
+                    frame.size.width = self.nextWidth;
                 if(initHidden && osVersion < 11){
                    frame.origin.x = -10000;
                 }

--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -87,24 +87,49 @@ static CDVWKInAppBrowser* instance = nil;
     return NO;
 }
 
+-(void)changeWindowSizeIfHidden:(CDVInvokedUrlCommand*)command
+{
+    CDVPluginResult* pluginResult = nil;
+    if (self->tmpWindow) { // tmpWindow gets set to nil when the window is hidden
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsInt:0];
+    } else {
+        CGRect webViewBounds = [self.webView bounds];
+        NSInteger height = (int)[command.arguments objectAtIndex:0];
+        NSInteger width = (int)[command.arguments objectAtIndex:1];
+
+        if (height == -1) {
+            height = self.originalHeight;
+        }
+        if (width == -1) {
+            width = self.originalWidth;
+        }
+        webViewBounds.size.height = height;
+        webViewBounds.size.width = width;
+        [self.webView setFrame:webViewBounds];
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsInt:1];
+    }
+ 
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+}
+
 - (void)open:(CDVInvokedUrlCommand*)command
 {
     CDVPluginResult* pluginResult;
-    
+
     NSString* url = [command argumentAtIndex:0];
     NSString* target = [command argumentAtIndex:1 withDefault:kInAppBrowserTargetSelf];
     NSString* options = [command argumentAtIndex:2 withDefault:@"" andClass:[NSString class]];
-    
+
     self.callbackId = command.callbackId;
-    
+
     if (url != nil) {
         NSURL* baseUrl = [self.webViewEngine URL];
         NSURL* absoluteUrl = [[NSURL URLWithString:url relativeToURL:baseUrl] absoluteURL];
-        
+
         if ([self isSystemUrl:absoluteUrl]) {
             target = kInAppBrowserTargetSystem;
         }
-        
+
         if ([target isEqualToString:kInAppBrowserTargetSelf]) {
             [self openInCordovaWebView:absoluteUrl withOptions:options];
         } else if ([target isEqualToString:kInAppBrowserTargetSystem]) {
@@ -112,12 +137,12 @@ static CDVWKInAppBrowser* instance = nil;
         } else { // _blank or anything else
             [self openInInAppBrowser:absoluteUrl withOptions:options];
         }
-        
+
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
     } else {
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"incorrect number of arguments"];
     }
-    
+
     [pluginResult setKeepCallback:[NSNumber numberWithBool:YES]];
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
@@ -125,17 +150,17 @@ static CDVWKInAppBrowser* instance = nil;
 - (void)openInInAppBrowser:(NSURL*)url withOptions:(NSString*)options
 {
     CDVInAppBrowserOptions* browserOptions = [CDVInAppBrowserOptions parseOptions:options];
-    
+
     WKWebsiteDataStore* dataStore = [WKWebsiteDataStore defaultDataStore];
     if (browserOptions.cleardata) {
-        
+
         NSDate* dateFrom = [NSDate dateWithTimeIntervalSince1970:0];
         [dataStore removeDataOfTypes:[WKWebsiteDataStore allWebsiteDataTypes] modifiedSince:dateFrom completionHandler:^{
             NSLog(@"Removed all WKWebView data");
             self.inAppBrowserViewController.webView.configuration.processPool = [[WKProcessPool alloc] init]; // create new process pool to flush all data
         }];
     }
-    
+
     if (browserOptions.clearcache) {
         bool isAtLeastiOS11 = false;
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000
@@ -143,7 +168,7 @@ static CDVWKInAppBrowser* instance = nil;
             isAtLeastiOS11 = true;
         }
 #endif
-            
+
         if(isAtLeastiOS11){
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000
             // Deletes all cookies
@@ -171,7 +196,7 @@ static CDVWKInAppBrowser* instance = nil;
              }];
         }
     }
-    
+
     if (browserOptions.clearsessioncache) {
         bool isAtLeastiOS11 = false;
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000
@@ -200,12 +225,12 @@ static CDVWKInAppBrowser* instance = nil;
     if (self.inAppBrowserViewController == nil) {
         self.inAppBrowserViewController = [[CDVWKInAppBrowserViewController alloc] initWithBrowserOptions: browserOptions andSettings:self.commandDelegate.settings];
         self.inAppBrowserViewController.navigationDelegate = self;
-        
+
         if ([self.viewController conformsToProtocol:@protocol(CDVScreenOrientationDelegate)]) {
             self.inAppBrowserViewController.orientationDelegate = (UIViewController <CDVScreenOrientationDelegate>*)self.viewController;
         }
     }
-    
+
     [self.inAppBrowserViewController showLocationBar:browserOptions.location];
     [self.inAppBrowserViewController showToolBar:browserOptions.toolbar :browserOptions.toolbarposition];
     if (browserOptions.closebuttoncaption != nil || browserOptions.closebuttoncolor != nil) {
@@ -222,7 +247,7 @@ static CDVWKInAppBrowser* instance = nil;
         }
     }
     self.inAppBrowserViewController.modalPresentationStyle = presentationStyle;
-    
+
     // Set Transition Style
     UIModalTransitionStyle transitionStyle = UIModalTransitionStyleCoverVertical; // default
     if (browserOptions.transitionstyle != nil) {
@@ -233,7 +258,7 @@ static CDVWKInAppBrowser* instance = nil;
         }
     }
     self.inAppBrowserViewController.modalTransitionStyle = transitionStyle;
-    
+
     //prevent webView from bouncing
     if (browserOptions.disallowoverscroll) {
         if ([self.inAppBrowserViewController.webView respondsToSelector:@selector(scrollView)]) {
@@ -246,7 +271,7 @@ static CDVWKInAppBrowser* instance = nil;
             }
         }
     }
-    
+
     // use of beforeload event
     if([browserOptions.beforeload isKindOfClass:[NSString class]]){
         _beforeload = browserOptions.beforeload;
@@ -254,11 +279,13 @@ static CDVWKInAppBrowser* instance = nil;
         _beforeload = @"yes";
     }
     _waitForBeforeload = ![_beforeload isEqualToString:@""];
-    
+
     [self.inAppBrowserViewController navigateTo:url];
     if (!browserOptions.hidden) {
         [self show:nil withNoAnimate:browserOptions.hidden];
     }
+    self.originalHeight = [self.webView bounds].size.height;
+    self.originalWidth = [self.webView bounds].size.width;
 }
 
 - (void)show:(CDVInvokedUrlCommand*)command{

--- a/src/windows/InAppBrowserProxy.js
+++ b/src/windows/InAppBrowserProxy.js
@@ -127,6 +127,17 @@ var IAB = {
             browserWrap.style.display = 'none';
         }
     },
+    changeWindowSizeIfHidden: function (win, fail, args) {
+        if (!(browserWrap && browserWrap.style.display === 'none')) {
+            win(0)
+        } else {
+            var height = args[0] === -1 ? '100%' : args[0] + 'px'
+            var width = args[1] === -1 ? '100%' : args[1] + 'px'
+            browserWrap.style.height = height;
+            browserWrap.style.width = width;
+            win(1)
+        }
+    },
     open: function (win, lose, args) {
         // make function async so that we can add navigation events handlers before view is loaded and navigation occured
         setImmediate(function () {

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-inappbrowser-tests",
-  "version": "4.0.0-j5.5",
+  "version": "4.0.0-j5.6",
   "description": "",
   "cordova": {
     "id": "cordova-plugin-inappbrowser-tests",

--- a/tests/plugin.xml
+++ b/tests/plugin.xml
@@ -20,7 +20,7 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     id="cordova-plugin-inappbrowser-tests"
-    version="4.0.0-j5.5">
+    version="4.0.0-j5.6">
     <name>Cordova InAppBrowser Plugin Tests</name>
     <license>Apache 2.0</license>
 

--- a/www/inappbrowser.js
+++ b/www/inappbrowser.js
@@ -96,11 +96,7 @@
         },
 
         changeWindowSizeIfHidden: function (height, width, cb) {
-            if (device.platform.toLowerCase() === 'android') {
-                exec(cb, null, 'InAppBrowser', 'changeWindowSizeIfHidden', [height, width])
-            } else {
-                console.warn('changeWindowSizeIfHidden called but not implemented for ' + device.platform)
-            }
+            exec(cb, null, 'InAppBrowser', 'changeWindowSizeIfHidden', [height, width])
         }
     };
 


### PR DESCRIPTION
In https://github.com/j5int/cordova-plugin-inappbrowser/pull/17 I added a method on Android that allows you to change the IAB window size (if it's currently hidden) so that the IF window won't be noticeable when we put it into the foreground (to keep JS execution active). 
Since we don't fully understand why https://github.com/j5int/cordova-plugin-inappbrowser/pull/15 works, we've decided to show the window when clicking the sync tile in general so that we are guaranteed that the JS will execute. In order to do this unobtrusively I've added an implementation for changeWindowSizeIfHidden on iOS, as well as Windows just so that all platforms are doing the same thing.

Testing:
Changed some of the code here https://gitlab.sjsoft.com/j5-product/j5-mobile/merge_requests/1039 so that the keepIFWindowAwake method wasn't just limited to Android and changed the interval to 30s. I then checked on a Windows and iOS device that in both cases only the busy dialog was visible when the interval was up or when the sync tile was clicked e.g.
![image](https://user-images.githubusercontent.com/58415985/98588941-2c354880-22d5-11eb-8073-2e8e67240e78.png)
And that the IF window was the correct size afterwards. Also checked that the code did not run if the IF window was already in the foreground.