### PR TITLE
Fix footer truncation on iOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-inappbrowser",
-  "version": "4.0.0-j5.6",
+  "version": "4.0.0-j5.7",
   "description": "Cordova InAppBrowser Plugin",
   "types": "./types/index.d.ts",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -20,7 +20,7 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
            id="cordova-plugin-inappbrowser"
-      version="4.0.0-j5.6">
+      version="4.0.0-j5.7">
 
     <name>InAppBrowser</name>
     <description>Cordova InAppBrowser Plugin</description>

--- a/src/ios/CDVWKInAppBrowser.h
+++ b/src/ios/CDVWKInAppBrowser.h
@@ -39,8 +39,7 @@
 @property (nonatomic, copy) NSString* callbackId;
 @property (nonatomic, copy) NSRegularExpression *callbackIdPattern;
 
-@property NSInteger nextHeight;
-@property NSInteger nextWidth;
+@property bool inSmallWindowMode;
 
 + (id) getInstance;
 - (void)open:(CDVInvokedUrlCommand*)command;

--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -89,16 +89,13 @@ static CDVWKInAppBrowser* instance = nil;
     return NO;
 }
 
--(void)changeWindowSizeIfHidden:(CDVInvokedUrlCommand*)command
+-(void)setSmallWindowModeIfHidden:(CDVInvokedUrlCommand*)command
 {
     CDVPluginResult* pluginResult = nil;
     if (_previousStatusBarStyle != -1) { // indicates that the window is not currently hidden (see hide method)
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsInt:0];
     } else {
-        NSInteger height = [([command.arguments objectAtIndex:0]) integerValue];
-        NSInteger width = [([command.arguments objectAtIndex:1]) integerValue];
-        self.nextHeight = height;
-        self.nextWidth = width;
+        self.inSmallWindowMode = [([command.arguments objectAtIndex:0]) boolValue];
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsInt:1];
     }
  
@@ -277,8 +274,7 @@ static CDVWKInAppBrowser* instance = nil;
     if (!browserOptions.hidden) {
         [self show:nil withNoAnimate:browserOptions.hidden];
     }
-    self.nextHeight = -1;
-    self.nextWidth = -1;
+    self.inSmallWindowMode = NO;
 }
 
 - (void)show:(CDVInvokedUrlCommand*)command{
@@ -320,10 +316,10 @@ static CDVWKInAppBrowser* instance = nil;
             __strong __typeof(weakSelf) strongSelf = weakSelf;
             if (!strongSelf->tmpWindow) {
                 CGRect frame = [[UIScreen mainScreen] bounds];
-                if (self.nextHeight != -1)
-                    frame.size.height = self.nextHeight;
-                if (self.nextWidth != -1)
-                    frame.size.width = self.nextWidth;
+                if (self.inSmallWindowMode) {
+                    frame.size.height = 1;
+                    frame.size.width = 1;
+                }
                 if(initHidden && osVersion < 11){
                    frame.origin.x = -10000;
                 }

--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -40,6 +40,8 @@
 
 #pragma mark CDVWKInAppBrowser
 
+CGFloat lastReducedStatusBarHeight = 0.0;
+
 @interface CDVWKInAppBrowser () {
     NSInteger _previousStatusBarStyle;
 }
@@ -701,6 +703,7 @@ static CDVWKInAppBrowser* instance = nil;
     }
     
     _previousStatusBarStyle = -1; // this value was reset before reapplying it. caused statusbar to stay black on ios7
+    lastReducedStatusBarHeight = 0.0;
 }
 
 @end //CDVWKInAppBrowser
@@ -711,7 +714,7 @@ static CDVWKInAppBrowser* instance = nil;
 
 @synthesize currentURL;
 
-CGFloat lastReducedStatusBarHeight = 0.0;
+
 
 - (id)initWithBrowserOptions: (CDVInAppBrowserOptions*) browserOptions andSettings:(NSDictionary *)settings
 {

--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -1112,6 +1112,13 @@ static CDVWKInAppBrowser* instance = nil;
 }
 
 - (void) rePositionViews {
+    if (self.navigationDelegate.inSmallWindowMode) {
+        // we don't need to account for the toolbar height etc when the window isn't visible;
+        // furthermore lastReducedStatusBarHeight would get set prematurely and the window won't resize properly
+        // when maximised
+        return;
+    }
+
     CGRect viewBounds = [self.webView bounds];
     CGFloat statusBarHeight = [self getStatusBarOffset];
     

--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -790,7 +790,7 @@ static CDVWKInAppBrowser* instance = nil;
     self.webView.multipleTouchEnabled = YES;
     self.webView.opaque = YES;
     self.webView.userInteractionEnabled = YES;
-    self.automaticallyAdjustsScrollViewInsets = NO ;
+    self.automaticallyAdjustsScrollViewInsets = YES ;
     [self.webView setAutoresizingMask:UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth];
     self.webView.allowsLinkPreview = NO;
     self.webView.allowsBackForwardNavigationGestures = NO;

--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -791,7 +791,7 @@ CGFloat lastReducedStatusBarHeight = 0.0;
     self.webView.multipleTouchEnabled = YES;
     self.webView.opaque = YES;
     self.webView.userInteractionEnabled = YES;
-    self.automaticallyAdjustsScrollViewInsets = YES ;
+    self.automaticallyAdjustsScrollViewInsets = NO ;
     [self.webView setAutoresizingMask:UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth];
     self.webView.allowsLinkPreview = NO;
     self.webView.allowsBackForwardNavigationGestures = NO;

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-inappbrowser-tests",
-  "version": "4.0.0-j5.6",
+  "version": "4.0.0-j5.7",
   "description": "",
   "cordova": {
     "id": "cordova-plugin-inappbrowser-tests",

--- a/tests/plugin.xml
+++ b/tests/plugin.xml
@@ -20,7 +20,7 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     id="cordova-plugin-inappbrowser-tests"
-    version="4.0.0-j5.6">
+    version="4.0.0-j5.7">
     <name>Cordova InAppBrowser Plugin Tests</name>
     <license>Apache 2.0</license>
 

--- a/www/inappbrowser.js
+++ b/www/inappbrowser.js
@@ -95,8 +95,13 @@
             }
         },
 
-        changeWindowSizeIfHidden: function (height, width, cb) {
-            exec(cb, null, 'InAppBrowser', 'changeWindowSizeIfHidden', [height, width])
+        setSmallWindowModeIfHidden: function (minimiseWindow, cb) {
+            if (device.platform === 'iOS') {
+                exec(cb, null, 'InAppBrowser', 'setSmallWindowModeIfHidden', [minimiseWindow]);
+            } else {
+                var size = minimiseWindow ? 1 : -1;
+                exec(cb, null, 'InAppBrowser', 'changeWindowSizeIfHidden', [size, size])
+            }
         }
     };
 


### PR DESCRIPTION
On iOS we were experiencing an issue where the window's bounds exceeded the screen height and as a result the footer would be hidden and you wouldn't be able to scroll down to interact with it. This was caused by the height calculations going awry when the window was changed to 1x1 (a workaround for foregrounding the window without the user seeing it) so to avoid these complexities I'm just changing the width to 1px and leaving the height unchanged. In this case I turn off the animation so that it isn't as noticeable on screen. 

I also fixed a bug where a global variable wasn't being reset when the browser window was closed which would also cause a height miscalculation if the user logged out and in again without closing the app. Details below:

In the iOS WKWebView implementation; each time the window is shown, rePositionViews gets called and does the following:
```
    CGFloat statusBarHeight = [self getStatusBarOffset];
    
    // orientation portrait or portraitUpsideDown: status bar is on the top and web view is to be aligned to the bottom of the status bar
    // orientation landscapeLeft or landscapeRight: status bar height is 0 in but lets account for it in case things ever change in the future
    viewBounds.origin.y = statusBarHeight;
    
    // account for web view height portion that may have been reduced by a previous call to this method
    viewBounds.size.height = viewBounds.size.height - statusBarHeight + lastReducedStatusBarHeight;
    lastReducedStatusBarHeight = statusBarHeight;
```

The first time this gets called, `lastReducedStatusBarHeight` (a global variable) will be zero and the status bar height will be subtracted from the view's height. On subsequent calls, nothing will be subtracted because `lastReducedStatusBarHeight` now contains the status bar height. 

 `lastReducedStatusBarHeight` wasn't being cleared when the browser was closed when logging out and as a result if you logged in again no adjustment would be made for the status bar and the window would be larger than screen.

